### PR TITLE
🗃 추가 프로필 이미지 컬럼

### DIFF
--- a/src/main/java/com/umc/ttg/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/ttg/domain/member/entity/Member.java
@@ -17,6 +17,8 @@ public class Member extends Time {
     @Column(nullable = false, length = 20)
     private String nickname;
 
+    private String profileImage;
+
     @Column(length = 15)
     private String phoneNum;
 


### PR DESCRIPTION
profile_image 컬럼 추가했습니다.

설정하지 않았을 시에는 기본 이미지로 나가는 걸로 생각하고  null 가능 상태로 해두었습니다.