### PR TITLE
:bug: 수정 PUBLIC.CONSTRAINT_INDEX_4에 있는 UNIQUE 인덱스나 기본 키 제약 조건을 위반 오류

### DIFF
--- a/src/main/java/com/umc/ttg/domain/store/entity/Store.java
+++ b/src/main/java/com/umc/ttg/domain/store/entity/Store.java
@@ -43,11 +43,11 @@ public class Store extends Time {
     @Column(nullable = false)
     private String address;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private Region region;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
 


### PR DESCRIPTION
- menu_id 에 중복된 값을 삽입하려고 했다는 오류 발생
- OneToOne 은 서로의 테이블에서 유일하게 하나의 값씩만 맵핑되어야 하는 것
- 즉, Store 에 menu_id 1번을 가진 가게가 하나여야만 하는 것
- ManyToOne 으로 menu, region 맵핑 관계 수정 (Store 입장에서는 카테고리가 하나여야 하지만, 카테고리 입장에서는 여러 Store 에 쓰일 수 있기 때문)