### PR TITLE
Feature/30 feature look up my page

### DIFF
--- a/src/main/java/com/umc/ttg/domain/coupon/dto/MyPageCouponResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/coupon/dto/MyPageCouponResponseDTO.java
@@ -1,4 +1,4 @@
-package com.umc.ttg.domain.member.dto;
+package com.umc.ttg.domain.coupon.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -7,7 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class MyPageResponseDto {
+public class MyPageCouponResponseDTO {
 
-
+    private Long id;
+    private String content;
 }

--- a/src/main/java/com/umc/ttg/domain/coupon/dto/MyPageCouponResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/coupon/dto/MyPageCouponResponseDTO.java
@@ -1,10 +1,11 @@
 package com.umc.ttg.domain.coupon.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Data
+@Data @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class MyPageCouponResponseDTO {

--- a/src/main/java/com/umc/ttg/domain/coupon/dto/converter/CouponConverter.java
+++ b/src/main/java/com/umc/ttg/domain/coupon/dto/converter/CouponConverter.java
@@ -1,0 +1,19 @@
+package com.umc.ttg.domain.coupon.dto.converter;
+
+import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
+import com.umc.ttg.domain.coupon.entity.Coupon;
+
+public class CouponConverter {
+
+    public static MyPageCouponResponseDTO convertToMyCouponDto(Coupon coupon) {
+        if (coupon == null) {
+            return null;
+        }
+
+        MyPageCouponResponseDTO couponResponseDTO = new MyPageCouponResponseDTO();
+        couponResponseDTO.setId(coupon.getId());
+        couponResponseDTO.setContent(coupon.getContent());
+
+        return couponResponseDTO;
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/coupon/dto/converter/CouponConverter.java
+++ b/src/main/java/com/umc/ttg/domain/coupon/dto/converter/CouponConverter.java
@@ -10,10 +10,9 @@ public class CouponConverter {
             return null;
         }
 
-        MyPageCouponResponseDTO couponResponseDTO = new MyPageCouponResponseDTO();
-        couponResponseDTO.setId(coupon.getId());
-        couponResponseDTO.setContent(coupon.getContent());
-
-        return couponResponseDTO;
+        return MyPageCouponResponseDTO.builder()
+                .id(coupon.getId())
+                .content(coupon.getContent())
+                .build();
     }
 }

--- a/src/main/java/com/umc/ttg/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/umc/ttg/domain/coupon/repository/CouponRepository.java
@@ -4,7 +4,9 @@ import com.umc.ttg.domain.coupon.entity.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
     List<Coupon> findAllByMemberId(Long memberId);
+    Optional<Coupon> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
@@ -1,7 +1,7 @@
 package com.umc.ttg.domain.member.api;
 
 import com.umc.ttg.domain.member.application.MemberQueryService;
-import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.domain.member.dto.MyPageAllResponseDto;
 import com.umc.ttg.global.common.BaseResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
+@RequestMapping("/members/profile")
 public class MemberController {
 
     private final MemberQueryService memberService;
     @GetMapping
-    public BaseResponseDto<MyPageResponseDto> getMyPage() {
+    public BaseResponseDto<MyPageAllResponseDto> getMyPage() {
 
-        return null;
+        return memberService.lookUp();
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
@@ -1,0 +1,22 @@
+package com.umc.ttg.domain.member.api;
+
+import com.umc.ttg.domain.member.application.MemberQueryService;
+import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.global.common.BaseResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberQueryService memberService;
+    @GetMapping
+    public BaseResponseDto<MyPageResponseDto> getMyPage() {
+
+        return null;
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
@@ -17,6 +17,6 @@ public class MemberController {
     @GetMapping
     public BaseResponseDto<MyPageAllResponseDto> getMyPage() {
 
-        return memberService.lookUp();
+        return memberService.myPageLookUp();
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/api/api.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/api.java
@@ -1,4 +1,0 @@
-package com.umc.ttg.domain.member.api;
-
-public class api {
-}

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
@@ -1,8 +1,8 @@
 package com.umc.ttg.domain.member.application;
 
-import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.domain.member.dto.MyPageAllResponseDto;
 import com.umc.ttg.global.common.BaseResponseDto;
 
 public interface MemberQueryService {
-    BaseResponseDto<MyPageResponseDto> lookUpMyPage();
+    BaseResponseDto<MyPageAllResponseDto> lookUp();
 }

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
@@ -4,5 +4,5 @@ import com.umc.ttg.domain.member.dto.MyPageAllResponseDto;
 import com.umc.ttg.global.common.BaseResponseDto;
 
 public interface MemberQueryService {
-    BaseResponseDto<MyPageAllResponseDto> lookUp();
+    BaseResponseDto<MyPageAllResponseDto> myPageLookUp();
 }

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryService.java
@@ -1,0 +1,8 @@
+package com.umc.ttg.domain.member.application;
+
+import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.global.common.BaseResponseDto;
+
+public interface MemberQueryService {
+    BaseResponseDto<MyPageResponseDto> lookUpMyPage();
+}

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
@@ -1,27 +1,31 @@
 package com.umc.ttg.domain.member.application;
 
 import com.umc.ttg.domain.coupon.repository.CouponRepository;
-import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.domain.member.dto.MyPageAllResponseDto;
+import com.umc.ttg.domain.member.dto.converter.MemberConverter;
 import com.umc.ttg.domain.member.entity.Member;
+import com.umc.ttg.domain.member.exception.handler.MemberHandler;
 import com.umc.ttg.domain.member.repository.MemberRepository;
-import com.umc.ttg.domain.review.entity.Review;
-import com.umc.ttg.domain.store.repository.StoreRepository;
+import com.umc.ttg.domain.review.dto.MyPageReviewResponseDTO;
+import com.umc.ttg.domain.review.repository.ReviewRepository;
 import com.umc.ttg.global.common.BaseResponseDto;
 import com.umc.ttg.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class MemberQueryServiceImpl implements MemberQueryService {
 
-    MemberRepository memberRepository;
-    CouponRepository couponRepository;
-    ReviewRepository reviewRepository;
-    StoreRepository storeRepository;
+    private final MemberRepository memberRepository;
+    private final CouponRepository couponRepository;
+    private final ReviewRepository reviewRepository;
 
     @Override
-    public BaseResponseDto<MyPageResponseDto> lookUpMyPage() {
+    public BaseResponseDto<MyPageAllResponseDto> lookUp() {
 
         /**
          * 추후에 token을 통해 Member 정보를 가져올 예정
@@ -29,13 +33,16 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         Long memberId = 1L;
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ReponseCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberHandler(ResponseCode.MEMBER_NOT_FOUND));
 
-        List<Review> reviews = reviewRepository.findAllById(memberId)
-                .orElseThrow(() -> new MemberHandler(ReponseCode.MMBER_NOT_FOUND));
+        List<MyPageReviewResponseDTO> reviews = reviewRepository.findAllByMemberId(memberId)
+                .stream().map(review -> MyPageReviewResponseDTO.of(review, couponRepository))
+                .collect(Collectors.toList());
 
+        MyPageAllResponseDto myPageDto = new MyPageAllResponseDto();
+        myPageDto.setMember(MemberConverter.convertToMyMemberDto(member));
+        myPageDto.setReviewDtos(reviews);
 
-
-        return BaseResponseDto.onSuccess(ResponseCode.OK);
+        return BaseResponseDto.onSuccess(myPageDto, ResponseCode.OK);
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
@@ -25,7 +25,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final ReviewRepository reviewRepository;
 
     @Override
-    public BaseResponseDto<MyPageAllResponseDto> lookUp() {
+    public BaseResponseDto<MyPageAllResponseDto> myPageLookUp() {
 
         /**
          * 추후에 token을 통해 Member 정보를 가져올 예정

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberQueryServiceImpl.java
@@ -1,0 +1,41 @@
+package com.umc.ttg.domain.member.application;
+
+import com.umc.ttg.domain.coupon.repository.CouponRepository;
+import com.umc.ttg.domain.member.dto.MyPageResponseDto;
+import com.umc.ttg.domain.member.entity.Member;
+import com.umc.ttg.domain.member.repository.MemberRepository;
+import com.umc.ttg.domain.review.entity.Review;
+import com.umc.ttg.domain.store.repository.StoreRepository;
+import com.umc.ttg.global.common.BaseResponseDto;
+import com.umc.ttg.global.common.ResponseCode;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MemberQueryServiceImpl implements MemberQueryService {
+
+    MemberRepository memberRepository;
+    CouponRepository couponRepository;
+    ReviewRepository reviewRepository;
+    StoreRepository storeRepository;
+
+    @Override
+    public BaseResponseDto<MyPageResponseDto> lookUpMyPage() {
+
+        /**
+         * 추후에 token을 통해 Member 정보를 가져올 예정
+         */
+        Long memberId = 1L;
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ReponseCode.MEMBER_NOT_FOUND));
+
+        List<Review> reviews = reviewRepository.findAllById(memberId)
+                .orElseThrow(() -> new MemberHandler(ReponseCode.MMBER_NOT_FOUND));
+
+
+
+        return BaseResponseDto.onSuccess(ResponseCode.OK);
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/member/application/application.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/application.java
@@ -1,4 +1,0 @@
-package com.umc.ttg.domain.member.application;
-
-public class application {
-}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MyPageAllResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MyPageAllResponseDto.java
@@ -1,0 +1,17 @@
+package com.umc.ttg.domain.member.dto;
+
+import com.umc.ttg.domain.review.dto.MyPageReviewResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageAllResponseDto {
+
+    private MyPageMemberResponseDTO member;
+    private List<MyPageReviewResponseDTO> reviewDtos;
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MyPageMemberResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MyPageMemberResponseDTO.java
@@ -1,12 +1,14 @@
 package com.umc.ttg.domain.member.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class MyPageMemberResponseDTO {
 
     private Long memberId;

--- a/src/main/java/com/umc/ttg/domain/member/dto/MyPageMemberResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MyPageMemberResponseDTO.java
@@ -1,0 +1,15 @@
+package com.umc.ttg.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageMemberResponseDTO {
+
+    private Long memberId;
+    private String nickname;
+    private int benefitCount;
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MyPageResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MyPageResponseDto.java
@@ -1,0 +1,8 @@
+package com.umc.ttg.domain.member.dto;
+
+public class MyPageResponseDto {
+
+    private Long id;
+    private String nickname;
+    private int benefitCount;
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MyPageResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MyPageResponseDto.java
@@ -1,8 +1,13 @@
 package com.umc.ttg.domain.member.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MyPageResponseDto {
 
-    private Long id;
-    private String nickname;
-    private int benefitCount;
+
 }

--- a/src/main/java/com/umc/ttg/domain/member/dto/converter/MemberConverter.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/converter/MemberConverter.java
@@ -7,12 +7,10 @@ public class MemberConverter {
 
     public static MyPageMemberResponseDTO convertToMyMemberDto(Member member){
 
-        MyPageMemberResponseDTO memberResponseDTO = new MyPageMemberResponseDTO();
-
-        memberResponseDTO.setMemberId(member.getId());
-        memberResponseDTO.setNickname(member.getNickname());
-        memberResponseDTO.setBenefitCount(member.getBenefitCount());
-
-        return memberResponseDTO;
+        return MyPageMemberResponseDTO.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .benefitCount(member.getBenefitCount())
+                .build();
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/dto/converter/MemberConverter.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/converter/MemberConverter.java
@@ -1,0 +1,18 @@
+package com.umc.ttg.domain.member.dto.converter;
+
+import com.umc.ttg.domain.member.dto.MyPageMemberResponseDTO;
+import com.umc.ttg.domain.member.entity.Member;
+
+public class MemberConverter {
+
+    public static MyPageMemberResponseDTO convertToMyMemberDto(Member member){
+
+        MyPageMemberResponseDTO memberResponseDTO = new MyPageMemberResponseDTO();
+
+        memberResponseDTO.setMemberId(member.getId());
+        memberResponseDTO.setNickname(member.getNickname());
+        memberResponseDTO.setBenefitCount(member.getBenefitCount());
+
+        return memberResponseDTO;
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/dto.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/dto.java
@@ -1,4 +1,0 @@
-package com.umc.ttg.domain.member.dto;
-
-public class dto {
-}

--- a/src/main/java/com/umc/ttg/domain/review/dto/MyPageReviewResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/review/dto/MyPageReviewResponseDTO.java
@@ -1,0 +1,47 @@
+package com.umc.ttg.domain.review.dto;
+
+import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
+import com.umc.ttg.domain.coupon.repository.CouponRepository;
+import com.umc.ttg.domain.review.entity.Review;
+import com.umc.ttg.domain.review.entity.ReviewStatus;
+import com.umc.ttg.domain.store.dto.MyPageStoreResponseDto;
+import com.umc.ttg.domain.store.dto.converter.StoreConverter;
+import com.umc.ttg.domain.store.entity.Store;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+public class MyPageReviewResponseDTO {
+
+    private Long reviewId;
+    private ReviewStatus status;
+    private LocalDate applyDate;
+    private String reason;
+    private MyPageStoreResponseDto storeDto;
+
+    public static MyPageReviewResponseDTO of(Review review, CouponRepository couponRepository) {
+        MyPageStoreResponseDto myPageStoreResponseDto =
+                StoreConverter.convertToMyStoreDto(review.getStore(), couponRepository);
+
+        return MyPageReviewResponseDTO.builder()
+                .reviewId(review.getId())
+                .status(review.getStatus())
+                .applyDate(review.getApplyDate())
+                .reason(review.getReason())
+                .storeDto(myPageStoreResponseDto)
+                .build();
+    }
+
+    @Builder
+    private MyPageReviewResponseDTO(Long reviewId, ReviewStatus status, LocalDate applyDate, String reason, MyPageStoreResponseDto storeDto) {
+        this.reviewId = reviewId;
+        this.status = status;
+        this.applyDate = applyDate;
+        this.reason = reason;
+        this.storeDto = storeDto;
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/review/dto/MyPageReviewResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/review/dto/MyPageReviewResponseDTO.java
@@ -1,12 +1,10 @@
 package com.umc.ttg.domain.review.dto;
 
-import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
 import com.umc.ttg.domain.coupon.repository.CouponRepository;
 import com.umc.ttg.domain.review.entity.Review;
 import com.umc.ttg.domain.review.entity.ReviewStatus;
 import com.umc.ttg.domain.store.dto.MyPageStoreResponseDto;
 import com.umc.ttg.domain.store.dto.converter.StoreConverter;
-import com.umc.ttg.domain.store.entity.Store;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/umc/ttg/domain/review/dto/ReviewRegisterRequestDTO.java
+++ b/src/main/java/com/umc/ttg/domain/review/dto/ReviewRegisterRequestDTO.java
@@ -1,7 +1,6 @@
 package com.umc.ttg.domain.review.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,15 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReviewRegisterRequestDTO {
 
-    /*
-    @NotNull
-    private Long memberId;
-
-    @NotNull
-    private Long StoreId;
-     */
     @NotBlank
     private String reviewLink;
-
-    // private ReviewStatus status;
 }

--- a/src/main/java/com/umc/ttg/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/umc/ttg/domain/review/repository/ReviewRepository.java
@@ -3,5 +3,8 @@ package com.umc.ttg.domain.review.repository;
 import com.umc.ttg.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
@@ -1,0 +1,18 @@
+package com.umc.ttg.domain.store.dto;
+
+import com.umc.ttg.domain.coupon.dto.CouponResponseDto;
+import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageStoreResponseDto {
+
+    private Long storeId;
+    private String title;
+    private String image;
+    private MyPageCouponResponseDTO couponDto;
+}

--- a/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
@@ -2,10 +2,11 @@ package com.umc.ttg.domain.store.dto;
 
 import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Data
+@Data @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class MyPageStoreResponseDto {

--- a/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/MyPageStoreResponseDto.java
@@ -1,6 +1,5 @@
 package com.umc.ttg.domain.store.dto;
 
-import com.umc.ttg.domain.coupon.dto.CouponResponseDto;
 import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
@@ -51,11 +51,11 @@ public class StoreConverter {
             return null;
         }
 
-        // 로직이 복잡해져서 익숙한 코드로 작성하고 문제 없으면 builder 이용하겠습니다
-        MyPageStoreResponseDto storeResponseDto = new MyPageStoreResponseDto();
-        storeResponseDto.setStoreId(store.getId());
-        storeResponseDto.setTitle(store.getTitle());
-        storeResponseDto.setImage(store.getImage());
+        MyPageStoreResponseDto storeResponseDto = MyPageStoreResponseDto.builder()
+                .storeId(store.getId())
+                .title(store.getTitle())
+                .image(store.getImage())
+                .build();
 
         // Coupon 정보 설정
         Optional<Coupon> optionalCoupon = couponRepository.findByStoreId(store.getId());

--- a/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
@@ -1,9 +1,16 @@
 package com.umc.ttg.domain.store.dto.converter;
 
+import com.umc.ttg.domain.coupon.dto.MyPageCouponResponseDTO;
+import com.umc.ttg.domain.coupon.dto.converter.CouponConverter;
+import com.umc.ttg.domain.coupon.entity.Coupon;
+import com.umc.ttg.domain.coupon.repository.CouponRepository;
+import com.umc.ttg.domain.store.dto.MyPageStoreResponseDto;
 import com.umc.ttg.domain.store.dto.StoreCreateResponseDto;
 import com.umc.ttg.domain.store.dto.StoreFindResponseDto;
 import com.umc.ttg.domain.store.entity.Store;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
 
 public class StoreConverter {
 
@@ -34,5 +41,30 @@ public class StoreConverter {
                 .address(store.getAddress())
                 .sponInfo(store.getSponInfo())
                 .reviewCount(store.getReviewCount()).build();
+    }
+
+    /**
+     * Store와 CouponRepository를 받아 storeDto와 couponDto를 반환하는 기능
+     */
+    public static MyPageStoreResponseDto convertToMyStoreDto(Store store, CouponRepository couponRepository) {
+        if (store == null) {
+            return null;
+        }
+
+        // 로직이 복잡해져서 익숙한 코드로 작성하고 문제 없으면 builder 이용하겠습니다
+        MyPageStoreResponseDto storeResponseDto = new MyPageStoreResponseDto();
+        storeResponseDto.setStoreId(store.getId());
+        storeResponseDto.setTitle(store.getTitle());
+        storeResponseDto.setImage(store.getImage());
+
+        // Coupon 정보 설정
+        Optional<Coupon> optionalCoupon = couponRepository.findByStoreId(store.getId());
+
+        if (optionalCoupon.isPresent()) {
+            MyPageCouponResponseDTO couponResponseDTO = CouponConverter.convertToMyCouponDto(optionalCoupon.get());
+            storeResponseDto.setCouponDto(couponResponseDTO);
+        }
+
+        return storeResponseDto;
     }
 }

--- a/src/main/java/com/umc/ttg/global/common/ResponseCode.java
+++ b/src/main/java/com/umc/ttg/global/common/ResponseCode.java
@@ -28,7 +28,10 @@ public enum ResponseCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
     // Article Error
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
+
+    // Review Error
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "리뷰가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# 마이페이지 조회


### PR 이후 개발해야 하는 기능들

- [ ] StoreConverter 수정 결정

> StoreConverter가 StoreDto와 CouponDto를 처리 하는데 이를 수정해야 할지 고민
> 수정할 경우, API 명세서도 부분적으로 변경 필요

- [ ] 테스트 코드
- [ ] s3 

### 반영 브랜치

feature/30 feature look up my page

### 변경 사항

- 마이 페이지 조회 기능 구현
- 각 도메인에 마이페이지를 위한 responseDto 추가
- CouponRepository에 마이페이지에 사용할 함수 추가
- /members/profile 을 GET 조회 시 결과 출력(상점, id가 1인 회원 정보, 리뷰가 저장되어 있어야 정상 작동) 
- ResponseCode에 review 예외 추가
- 코드 스타일 변경(import, 주석, 공백)
- 주요 기능은 Member 도메인에서 작성(MemberController, MemberQueryServiceImpl)

### 테스트 결과

Postman 테스트 결과 이상 없습니다. 양식 좋아 보여서 카피하겠습니다 ㅎ

- 성공
![image](https://github.com/Ttottoga/BE/assets/105339362/339caaf7-614e-4cae-83ba-364694dbd9ce)

- 실패
![image](https://github.com/Ttottoga/BE/assets/105339362/e8d4d03c-f4eb-46ae-b781-90ab23647bc7)

> 멤버가 없을 경우에만 실패 처리, 리뷰와 상점, 쿠폰이 없을 경우는 별도의 처리 x