### PR TITLE
Feature/38 s3 link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 src/main/resources/application.properties
 src/main/resources/application-h2.properties
+src/main/resources/application-s3.properties

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/umc/ttg/domain/store/api/StoreController.java
+++ b/src/main/java/com/umc/ttg/domain/store/api/StoreController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/stores")
@@ -19,7 +21,7 @@ public class StoreController {
     private final StoreCommandService storeCommandService;
 
     @PostMapping
-    public BaseResponseDto<StoreCreateResponseDto> createStore(@ModelAttribute @Valid StoreCreateRequestDto storeCreateRequestDto) {
+    public BaseResponseDto<StoreCreateResponseDto> createStore(@ModelAttribute @Valid StoreCreateRequestDto storeCreateRequestDto) throws IOException {
 
         return storeCommandService.saveStore(storeCreateRequestDto);
 

--- a/src/main/java/com/umc/ttg/domain/store/application/StoreCommandService.java
+++ b/src/main/java/com/umc/ttg/domain/store/application/StoreCommandService.java
@@ -5,9 +5,11 @@ import com.umc.ttg.domain.store.dto.StoreCreateResponseDto;
 import com.umc.ttg.domain.store.dto.StoreFindResponseDto;
 import com.umc.ttg.global.common.BaseResponseDto;
 
+import java.io.IOException;
+
 public interface StoreCommandService {
 
-    BaseResponseDto<StoreCreateResponseDto> saveStore(StoreCreateRequestDto storeCreateRequestDto);
+    BaseResponseDto<StoreCreateResponseDto> saveStore(StoreCreateRequestDto storeCreateRequestDto) throws IOException;
 
     BaseResponseDto<StoreFindResponseDto> findStore(Long storeId);
 

--- a/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
+++ b/src/main/java/com/umc/ttg/domain/store/dto/converter/StoreConverter.java
@@ -3,14 +3,8 @@ package com.umc.ttg.domain.store.dto.converter;
 import com.umc.ttg.domain.store.dto.StoreCreateResponseDto;
 import com.umc.ttg.domain.store.dto.StoreFindResponseDto;
 import com.umc.ttg.domain.store.entity.Store;
-import org.springframework.web.multipart.MultipartFile;
 
 public class StoreConverter {
-
-    // MultiPartFile -> S3 링크로
-    public static String convertToS3ImageLink(MultipartFile multipartFile) {
-        return "이미지 링크";
-    }
 
     // Store 정보 -> StoreCreateResponseDto 로
     public static StoreCreateResponseDto convertToCreateStoreResponse(Long storeId) {

--- a/src/main/java/com/umc/ttg/domain/store/entity/Store.java
+++ b/src/main/java/com/umc/ttg/domain/store/entity/Store.java
@@ -68,7 +68,6 @@ public class Store extends Time {
 
         this.title = storeCreateRequestDto.getTitle();
         this.subTitle = storeCreateRequestDto.getSubTitle();
-        this.image = StoreConverter.convertToS3ImageLink(storeCreateRequestDto.getStoreImage());
         this.useInfo = storeCreateRequestDto.getUseInfo();
         this.saleInfo = storeCreateRequestDto.getSaleInfo();
         this.placeInfo = storeCreateRequestDto.getPlaceInfo();

--- a/src/main/java/com/umc/ttg/global/common/AwsS3.java
+++ b/src/main/java/com/umc/ttg/global/common/AwsS3.java
@@ -1,0 +1,14 @@
+package com.umc.ttg.global.common;
+
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AwsS3 {
+
+    private String key;
+    private String path;
+
+}

--- a/src/main/java/com/umc/ttg/global/common/ResponseCode.java
+++ b/src/main/java/com/umc/ttg/global/common/ResponseCode.java
@@ -30,6 +30,9 @@ public enum ResponseCode {
     // Coupon Error
     COUPON_NOT_FOUND(HttpStatus.BAD_REQUEST, "COUPON4001", "쿠폰이 없습니다."),
 
+    // AWS S3 Error
+    S3_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "S34001", "파일 업로드에 실패했습니다."),
+
     // Article Error
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/com/umc/ttg/global/config/AwsS3Config.java
+++ b/src/main/java/com/umc/ttg/global/config/AwsS3Config.java
@@ -1,0 +1,35 @@
+package com.umc.ttg.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public BasicAWSCredentials basicAWSCredentials() {
+        return new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3(BasicAWSCredentials basicAWSCredentials) {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/umc/ttg/global/config/config.java
+++ b/src/main/java/com/umc/ttg/global/config/config.java
@@ -1,4 +1,0 @@
-package com.umc.ttg.global.config;
-
-public class config {
-}

--- a/src/main/java/com/umc/ttg/global/error/handler/AwsS3Handler.java
+++ b/src/main/java/com/umc/ttg/global/error/handler/AwsS3Handler.java
@@ -1,0 +1,12 @@
+package com.umc.ttg.global.error.handler;
+
+import com.umc.ttg.global.common.ResponseCode;
+import com.umc.ttg.global.error.GeneralException;
+
+public class AwsS3Handler extends GeneralException {
+
+    public AwsS3Handler(ResponseCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/com/umc/ttg/global/util/AwsS3Service.java
+++ b/src/main/java/com/umc/ttg/global/util/AwsS3Service.java
@@ -1,0 +1,84 @@
+package com.umc.ttg.global.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.umc.ttg.global.common.AwsS3;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public AwsS3 upload(MultipartFile multipartFile, String directoryName) throws IOException {
+        File file = convertMultipartFileToFile(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert fail"));
+
+        return upload(file, directoryName);
+    }
+
+    private AwsS3 upload(File file, String directoryName) {
+        String key = randomFileName(file, directoryName);
+        String path = putS3(file, key);
+
+        removeFile(file);
+
+        return AwsS3
+                .builder()
+                .key(key)
+                .path(path)
+                .build();
+    }
+
+    private String randomFileName(File file, String directoryName) {
+        return directoryName + "/" + UUID.randomUUID() + file.getName();
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return getS3(bucket, fileName);
+    }
+
+    private String getS3(String bucket, String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeFile(File file) {
+        file.delete();
+    }
+
+    public Optional<File> convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+        File file = new File(System.getProperty("user.dir") + "/" + multipartFile.getOriginalFilename());
+
+        if(file.createNewFile()) {
+            try(FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write(multipartFile.getBytes());
+            }
+            return Optional.of(file);
+        }
+        return Optional.empty();
+    }
+
+    public void remove(AwsS3 awsS3) {
+        if (!amazonS3.doesObjectExist(bucket, awsS3.getKey())) {
+            throw new AmazonS3Exception("Object " + awsS3.getKey() + " does not exist!");
+        }
+        amazonS3.deleteObject(bucket, awsS3.getKey());
+    }
+}

--- a/src/main/java/com/umc/ttg/global/util/AwsS3Service.java
+++ b/src/main/java/com/umc/ttg/global/util/AwsS3Service.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.umc.ttg.global.common.AwsS3;
+import com.umc.ttg.global.common.ResponseCode;
+import com.umc.ttg.global.error.handler.AwsS3Handler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -27,7 +29,7 @@ public class AwsS3Service {
 
     public AwsS3 upload(MultipartFile multipartFile, String directoryName) throws IOException {
         File file = convertMultipartFileToFile(multipartFile)
-                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert fail"));
+                .orElseThrow(() -> new AwsS3Handler(ResponseCode.S3_UPLOAD_FAIL));
 
         return upload(file, directoryName);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 # properties connect
-spring.profiles.include=h2
+spring.profiles.include=h2, s3


### PR DESCRIPTION
### PR 이후 개발해야 하는 기능들

- [x] 예외처리

> MultipartFile -> File 변환했을 때, 빈 객체가 생성될 경우 오류 발생

```
File file = convertMultipartFileToFile(multipartFile)
                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File convert fail"));
```

- [ ] 테스트 코드

### 반영 브랜치

feature/38-s3-link

### 변경 사항

- AwsS3Service 추가

> upload 기능 구현 : upload 후, AwsS3 객체 반환하는데 AwsS3.getPath 가 S3 사진 객체의 링크

- Store 저장 기능 S3 기능 연동

### 테스트 결과

Postman 테스트 결과 현재는 이상 없습니다.

### S3 기능 사용 예

**이미지 저장 후, 이미지 링크 받아오기**

![image](https://github.com/Ttottoga/BE/assets/86754153/d65b6edc-e277-4307-9e84-8546eb5a13d1)

1. upload 함수에 multiPartFile, 저장할 경로(경로는 자신이 지정, coupon 관련 경로라면 couponImage, member 프로필 이미지라면 profileImage 이런 식으로)
2. 반환된 AwsS3 객체를 통해 getPath 를 받아서 DB 에 저장

