### PR TITLE
Feature/50 modify a profile image

### DIFF
--- a/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
@@ -1,22 +1,32 @@
 package com.umc.ttg.domain.member.api;
 
+import com.umc.ttg.domain.member.application.MemberCommandService;
 import com.umc.ttg.domain.member.application.MemberQueryService;
+import com.umc.ttg.domain.member.dto.MemberImageRequestDTO;
+import com.umc.ttg.domain.member.dto.MemberImageResponseDTO;
 import com.umc.ttg.domain.member.dto.MyPageAllResponseDto;
 import com.umc.ttg.global.common.BaseResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members/profile")
 public class MemberController {
 
-    private final MemberQueryService memberService;
+    private final MemberQueryService memberQueryService;
+    private final MemberCommandService memberCommandService;
     @GetMapping
     public BaseResponseDto<MyPageAllResponseDto> getMyPage() {
 
-        return memberService.myPageLookUp();
+        return memberQueryService.myPageLookUp();
+    }
+
+    @PostMapping("/image")
+    public BaseResponseDto<MemberImageResponseDTO> modifyProfileImage
+            (@RequestBody @Valid MemberImageRequestDTO memberImageRequestDTO) {
+
+        return memberCommandService.modifyImage(memberImageRequestDTO);
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
+++ b/src/main/java/com/umc/ttg/domain/member/api/MemberController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members/profile")
@@ -25,8 +27,8 @@ public class MemberController {
 
     @PostMapping("/image")
     public BaseResponseDto<MemberImageResponseDTO> modifyProfileImage
-            (@RequestBody @Valid MemberImageRequestDTO memberImageRequestDTO) {
+            (@ModelAttribute @Valid MemberImageRequestDTO memberImageRequestDTO) throws IOException {
 
-        return memberCommandService.modifyImage(memberImageRequestDTO);
+        return memberCommandService.updateImage(memberImageRequestDTO);
     }
 }

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberCommandService.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberCommandService.java
@@ -1,0 +1,12 @@
+package com.umc.ttg.domain.member.application;
+
+import com.umc.ttg.domain.member.dto.MemberImageRequestDTO;
+import com.umc.ttg.domain.member.dto.MemberImageResponseDTO;
+import com.umc.ttg.global.common.BaseResponseDto;
+
+import java.io.IOException;
+
+public interface MemberCommandService {
+
+    BaseResponseDto<MemberImageResponseDTO> updateImage(MemberImageRequestDTO memberImageRequestDTO) throws IOException;
+}

--- a/src/main/java/com/umc/ttg/domain/member/application/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttg/domain/member/application/MemberCommandServiceImpl.java
@@ -1,0 +1,50 @@
+package com.umc.ttg.domain.member.application;
+
+import com.umc.ttg.domain.member.dto.MemberImageRequestDTO;
+import com.umc.ttg.domain.member.dto.MemberImageResponseDTO;
+import com.umc.ttg.domain.member.entity.Member;
+import com.umc.ttg.domain.member.exception.handler.MemberHandler;
+import com.umc.ttg.domain.member.repository.MemberRepository;
+import com.umc.ttg.global.common.AwsS3;
+import com.umc.ttg.global.common.BaseResponseDto;
+import com.umc.ttg.global.common.ResponseCode;
+import com.umc.ttg.global.util.AwsS3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandServiceImpl implements MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final AwsS3Service awsS3Service;
+
+    @Override
+    public BaseResponseDto<MemberImageResponseDTO> updateImage(MemberImageRequestDTO memberImageRequestDTO) throws IOException {
+
+        // 로그인 구현되면 시큐리티에서 member 가져올 예정
+        Long memberId = 1L;
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ResponseCode.MEMBER_NOT_FOUND));
+
+        member.setProfileImage(getS3ImageLink(memberImageRequestDTO.getProfileImage()));
+
+        memberRepository.save(member);
+
+        MemberImageResponseDTO memberImageResponseDTO = new MemberImageResponseDTO(member.getId());
+
+        return BaseResponseDto.onSuccess(memberImageResponseDTO, ResponseCode.OK);
+    }
+
+    private String getS3ImageLink(MultipartFile multipartFile) throws IOException {
+
+        AwsS3 memberImage = awsS3Service.upload(multipartFile, "memberImage");
+
+        return memberImage.getPath();
+
+    }
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MemberImageRequestDTO.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MemberImageRequestDTO.java
@@ -1,0 +1,14 @@
+package com.umc.ttg.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberImageRequestDTO {
+
+    private MultipartFile profileImage;
+}

--- a/src/main/java/com/umc/ttg/domain/member/dto/MemberImageResponseDTO.java
+++ b/src/main/java/com/umc/ttg/domain/member/dto/MemberImageResponseDTO.java
@@ -1,0 +1,13 @@
+package com.umc.ttg.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberImageResponseDTO {
+
+    private Long memberId;
+}

--- a/src/main/java/com/umc/ttg/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/ttg/domain/member/entity/Member.java
@@ -2,12 +2,9 @@ package com.umc.ttg.domain.member.entity;
 
 import com.umc.ttg.global.util.Time;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Getter
+@Getter @Setter
 @Entity
 @NoArgsConstructor
 //@NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/umc/ttg/domain/review/application/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttg/domain/review/application/ReviewCommandServiceImpl.java
@@ -35,7 +35,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         Long memberId = 1L;
 
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreHandler(ResponseCode._BAD_REQUEST));
+                .orElseThrow(() -> new StoreHandler(ResponseCode.STORE_NOT_FOUND));
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ResponseCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/umc/ttg/global/common/ResponseCode.java
+++ b/src/main/java/com/umc/ttg/global/common/ResponseCode.java
@@ -37,7 +37,10 @@ public enum ResponseCode {
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 
     // Review Error
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "리뷰가 없습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "리뷰가 없습니다."),
+
+    // Store Error
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "상점이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
### PR 이후 개발해야 하는 기능들

- [ ] MEMBER 식별
- [x] 형식에 맞지 않는 사진을 저장할 경우 예외처리

> 로그인 기능 구현 후 수정

### 반영 브랜치

Feature/50 modify a profile image

### 변경 사항

- MemberContoller에서 변수 이름 변경
- POST 요청 시 프로필 사진 변경(S3 적용)
- MemberCommandServiceImpl에서 서비스 구현
- Member에 @Setter 추가. (최대한 builder를 활용하려고 했는데 기존 방식에서 적용하는데 어려움이 있어 setter를 사용했습니다.
- memberId로 memberRepository에서 특정 member를 가져온 후, set을 통해 profileImage를 변경하고 다시 저장했습니다. 

### 테스트 결과

Postman 테스트 결과 이상 없습니다.