### PR TITLE
:wrench: WebSecurityConfiguration 에서 csrf 보호 받지 않을 URI 추가

### DIFF
--- a/src/main/java/com/umc/ttg/global/auth/WebSecurityConfiguration.java
+++ b/src/main/java/com/umc/ttg/global/auth/WebSecurityConfiguration.java
@@ -43,11 +43,7 @@ public class WebSecurityConfiguration {
                 .cors(cors -> cors
                         .configurationSource(corsConfigurationSource())
                 )
-//                .csrf(CsrfConfigurer::disable)
-                .csrf(csrf -> csrf
-                        .ignoringRequestMatchers("/stores")
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                )
+                .csrf(CsrfConfigurer::disable)
                 .headers(header -> header.frameOptions(frameOptionsConfig -> frameOptionsConfig.disable()))
                 .httpBasic(HttpBasicConfigurer::disable)
                 .sessionManagement(sessionManagement -> sessionManagement

--- a/src/main/java/com/umc/ttg/global/auth/WebSecurityConfiguration.java
+++ b/src/main/java/com/umc/ttg/global/auth/WebSecurityConfiguration.java
@@ -35,7 +35,7 @@ public class WebSecurityConfiguration {
     private final DefaultOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-    private String[] permitAllUri = {"/", "/api/v1/auth/**", "oauth2/**", "/h2-console/**", "/stores/{store_id}", "/stores", "/stores/home", "/stores/region-categories/**", "/stores/menu-categories/**", "/stores/search/**"};
+    private String[] permitAllUri = {"/", "/api/v1/auth/**", "oauth2/**", "/h2-console/**", "/stores/{store-id}", "/stores", "/stores/home", "/stores/region-categories/**", "/stores/menu-categories/**", "/stores/search/**"};
 
     @Bean
     protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
@@ -45,6 +45,7 @@ public class WebSecurityConfiguration {
                 )
 //                .csrf(CsrfConfigurer::disable)
                 .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/stores")
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 )
                 .headers(header -> header.frameOptions(frameOptionsConfig -> frameOptionsConfig.disable()))


### PR DESCRIPTION
1. .ignoringRequestMatchers("/stores") 로 해당 URI 토큰 없이 받기 허용 - 개발 테스트용으로 사용하는 것이므로 허용